### PR TITLE
Update arquillian-glassfish-managed-6 to 1.0.0.Alpha1

### DIFF
--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -571,7 +571,7 @@
                     <dependency>
                         <groupId>org.jboss.arquillian.container</groupId>
                         <artifactId>arquillian-glassfish-managed-6</artifactId>
-                        <version>1.0.0.Final-SNAPSHOT</version>
+                        <version>1.0.0.Alpha1</version>
                     </dependency> 
                     <dependency>
                         <groupId>org.jboss.arquillian.protocol</groupId>


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com

The arquillian-glassfish-managed-6 is no longer a SNAPSHOT and does not need to be built.
https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-glassfish-managed-6/1.0.0.Alpha1/
