### PR TITLE
Fix the cditck-porting build

### DIFF
--- a/docker/run_cditck.sh
+++ b/docker/run_cditck.sh
@@ -72,47 +72,8 @@ unzip -q -o ${WORKSPACE}/latest-cdi-tck-dist.zip -d ${WORKSPACE}/
 GROUP_ID=jakarta.enterprise
 CDI_TCK_DIST=cdi-tck-${CDI_TCK_VERSION}
 
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/artifacts/cdi-tck-api-${CDI_TCK_VERSION}.jar \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-api \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=jar
-
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/artifacts/cdi-tck-core-impl-${CDI_TCK_VERSION}.jar \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-core-impl \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=jar
-
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/artifacts/cdi-tck-web-impl-${CDI_TCK_VERSION}.jar \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-web-impl \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=jar
-
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/artifacts/cdi-tck-ext-lib-${CDI_TCK_VERSION}.jar \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-ext-lib \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=jar
-
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/weld/jboss-tck-runner/src/test/tck20/tck-tests.xml \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-core-impl \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=xml
-
-mvn --global-settings "${TS_HOME}/settings.xml" org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
--Dfile=${WORKSPACE}/${CDI_TCK_DIST}/artifacts/cdi-tck-parent-${CDI_TCK_VERSION}.pom \
--DgroupId=${GROUP_ID} \
--DartifactId=cdi-tck-parent \
--Dversion=${CDI_TCK_VERSION} \
--Dpackaging=pom
+cd ${CDI_TCK_DIST}/artifacts
+mvn --global-settings "${TS_HOME}/settings.xml" install
 
 which ant
 ant -version

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -226,19 +226,9 @@
             <version>1.0.0.CR2</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.test-audit</groupId>
-            <artifactId>jboss-test-audit-api</artifactId>
-            <version>1.1.4.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.test-audit</groupId>
-            <artifactId>jboss-test-audit-impl</artifactId>
-            <version>1.1.4.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.14.3</version>
+            <version>7.4.0</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -42,7 +42,7 @@
         <htmlunit.version>2.9</htmlunit.version>
         <shrinkwrap.version>1.0.1</shrinkwrap.version>
         <minimum.maven.version>3.0.5</minimum.maven.version>
-        <cdi.tck.version>4.0.0</cdi.tck.version>
+        <cdi.tck.version>4.0.3</cdi.tck.version>
         <httpcomponents.version>4.5.5</httpcomponents.version>
         <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
         <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -44,7 +44,7 @@
         <minimum.maven.version>3.0.5</minimum.maven.version>
         <cdi.tck.version>4.0.0</cdi.tck.version>
         <httpcomponents.version>4.5.5</httpcomponents.version>
-        <version.arquillian_core>1.7.0.Final-SNAPSHOT</version.arquillian_core>
+        <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
         <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>
     </properties>
 

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.0.CR2</version>
+        <version>5.0.0.SP1</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/settings.xml
+++ b/settings.xml
@@ -30,15 +30,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>jboss</id>
-      <name>Jboss Central Repository</name>
-      <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
-      <layout>default</layout>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>jakarta</id>
       <name>Jakarta Staging Repository</name>
       <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>


### PR DESCRIPTION
These changes fix the current 503 errors and update to the correct latest versions. The associated jakartaee-tck build job is now working:

https://ci.eclipse.org/jakartaee-tck/job/cditck-porting/job/master/171/console