### PR TITLE
More updates for jboss.repository.org failures

### DIFF
--- a/docker/run_cditck.sh
+++ b/docker/run_cditck.sh
@@ -49,14 +49,7 @@ if [ -z "${CDI_TCK_BUNDLE_URL}" ]; then
   CDI_TCK_BUNDLE_URL=https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.0-dist.zip
 fi
 
-rm -fr arquillian-core-master 
-wget https://github.com/arquillian/arquillian-core/archive/master.zip -O arquillian-core.zip
-unzip -q -o arquillian-core.zip
-cd arquillian-core-master
-mvn --global-settings "${TS_HOME}/settings.xml" clean install -DskipTests
-cd $WORKSPACE
-
-rm -fr glassfish-cdi-porting-tck-master 
+rm -fr glassfish-cdi-porting-tck-master
 wget https://github.com/eclipse-ee4j/glassfish-cdi-porting-tck/archive/master.zip -O glassfish-cdi-porting-tck.zip
 unzip -q -o glassfish-cdi-porting-tck.zip
 cd glassfish-cdi-porting-tck-master

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -42,7 +42,7 @@
         <htmlunit.version>2.9</htmlunit.version>
         <shrinkwrap.version>1.0.1</shrinkwrap.version>
         <minimum.maven.version>3.0.5</minimum.maven.version>
-        <cdi.tck.version>4.0.3</cdi.tck.version>
+        <cdi.tck.version>4.0.4</cdi.tck.version>
         <httpcomponents.version>4.5.5</httpcomponents.version>
         <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
         <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>
@@ -483,6 +483,14 @@
                     <artifactId>container-se-api</artifactId>
                     <groupId>org.jboss.arquillian.container</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.test-audit</groupId>
+                    <artifactId>jboss-test-audit-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.test-audit</groupId>
+                    <artifactId>jboss-test-audit-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -495,6 +503,14 @@
                 <exclusion>
                     <artifactId>container-se-api</artifactId>
                     <groupId>org.jboss.arquillian.container</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.test-audit</groupId>
+                    <artifactId>jboss-test-audit-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.test-audit</groupId>
+                    <artifactId>jboss-test-audit-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -410,6 +410,10 @@
                     <groupId>org.testng</groupId>
                     <artifactId>testng</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -541,6 +545,11 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
Using this repo, the following job got to the point of running the tck:
https://ci.eclipse.org/jakartaee-tck/job/cditck-porting/job/master/179/console